### PR TITLE
Anibel - Edges - Matrix Checksum

### DIFF
--- a/lib/matrix_check_sum.rb
+++ b/lib/matrix_check_sum.rb
@@ -3,5 +3,36 @@
 # of numbers in row i is the same as the sum of numbers in column i for i = 0 to row.length-1
 # If this is the case, return true. Otherwise, return false.
 def matrix_check_sum(matrix)
-  raise NotImplementedError
+
+  length = matrix.length
+
+  row_sums = {}
+  col_sums = {}
+
+  length.times do |row|
+    matrix[row].each_with_index do |num, index|
+      if row_sums.include?(index)
+        row_sums[index] += num
+      else
+        row_sums[index] = num
+      end
+
+      if col_sums.include?(row)
+        col_sums[row] += num
+      else
+        col_sums[row] = num
+      end
+
+    end
+
+  end
+
+  row_sums.each do |row, sum|
+    if col_sums[row] != sum
+      return false
+    end
+  end
+
+  return true
+
 end


### PR DESCRIPTION
Time complexity: `O(n^2)` where `n` is the length of the column or row of the input matrix (square matrix). This is because the algorithm iterates through each value in the matrix to get the sum for that column/row and then additionally compares the stored hash of `2*n` values to return a boolean: `O(n^2 + 2*n)` but since `2*n` is less significant than `n^2`, we can drop that value from the time complexity.

Space complexity: `O(n)` where `n` is the same as above. We end up using 2 hashes of size `n` but drop the constant in Big O notation.